### PR TITLE
Feature proxy

### DIFF
--- a/lib/src/utils/polyline_request.dart
+++ b/lib/src/utils/polyline_request.dart
@@ -95,7 +95,7 @@ class PolylineRequest {
 
     //Add proxyUrl to the beginning of the URI
     if (proxyUrl != null) {
-      return Uri.parse(proxyUrl! + uri.toString());
+      return Uri.parse(proxyUrl! + Uri.encodeQueryComponent(uri.toString()));
     }
 
     return uri;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  http: ^0.13.6
+  http: ^1.0.0
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  http: ^1.0.0
+  http: ^0.13.6
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Needed to encode Query Component as I send the whole URI as a query parameter and it contains additional query parameters.
I was not able to use CORS, but created a google cloud function as my proxy server and send the whole API url as query parameter to the proxy server